### PR TITLE
PR-76 issue #66 allow context in named templates

### DIFF
--- a/src/compiler/generate-xspec-tests.xsl
+++ b/src/compiler/generate-xspec-tests.xsl
@@ -208,7 +208,7 @@
                   <!-- Set up the $context variable -->
                   <xsl:apply-templates select="$context" mode="x:setup-context"/>
                   <!-- Switch to the context and call the template -->
-                  <for-each select="$context">
+                  <for-each select="$impl:context">
                     <xsl:copy-of select="$template-call" />
                   </for-each>
                 </xsl:when>

--- a/src/schemas/xspec.rnc
+++ b/src/schemas/xspec.rnc
@@ -113,7 +113,8 @@ function-scenario = function-call?,
 ## element defines the template call and the parameters passed to it and the
 ## <assertion> elements test the result of the template call. Child scenarios
 ## can override the parameters in the template call.
-named-scenario = template-call?, 
+named-scenario = context?,
+                 template-call?, 
                  like*,
                  (pending | assertion)*,
                  (pending | 


### PR DESCRIPTION
- change schema to allow context in named scenario
- add $impl to context (now $impl:context)

References in original XSpec project:
PR 76: https://github.com/expath/xspec/pull/76
issue 66: https://github.com/expath/xspec/issues/66